### PR TITLE
New method to return formatted api response error messages

### DIFF
--- a/lib/intacct/function_result.rb
+++ b/lib/intacct/function_result.rb
@@ -13,8 +13,18 @@ module Intacct
     end
 
     def parsed_data
-      hash = Crack::XML.parse(@xml_data.to_s)
+      hash = Crack::XML.parse(@xml_data.to_s).with_indifferent_access
       successful? ? hash.fetch('result') : hash
+    end
+
+    def push_error_messages
+      error_details = parsed_data.dig(:result, :errormessage, :error)
+
+      error_details = [error_details] unless error_details.is_a?(Array)
+
+      error_details.compact.map do |error_data|
+        [error_data[:description2], error_data[:correction]].compact.join(' ')
+      end
     end
   end
 end

--- a/lib/intacct/version.rb
+++ b/lib/intacct/version.rb
@@ -1,3 +1,3 @@
 module Intacct
-  VERSION = "0.0.11"
+  VERSION = "0.0.12"
 end


### PR DESCRIPTION
New method `push_error_messages` in `FunctionResult`  to return formatted api response error messages. This is named for pushes only right now because unsure how the error response looks for a pull api error